### PR TITLE
Fix typo in command.ino

### DIFF
--- a/command.ino
+++ b/command.ino
@@ -7,7 +7,7 @@ void setup() {
 
 void loop() {
   while (digitalRead(btnPin) == HIGH) {
-    // do nothing until pin 2 goes low
+    // do nothing until pin 5 goes low
     delay(100);
   }
   


### PR DESCRIPTION
`pin 2` should be `pin 5` (see `btnPin` declaration)